### PR TITLE
Add a method to hook each of the PSNG macros with custom code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ This repo was originally a fork of <https://github.com/verser-git/probe_screen_v
    ```sh
    /python
    /psng
-   /macros
    ```
 
 4. Copy .axisrc to your home ~/ folder. If you are already using .axisrc, then only add to your file contents of this .axisrc.

--- a/docs/setup-dev-environment.md
+++ b/docs/setup-dev-environment.md
@@ -1,9 +1,11 @@
+# Setup a Development Environment
+
+```
 cd $HOME
 git clone git@github.com:linuxcnc-probe-screen/probe-screen-ng.git
 cd $HOME/linuxccnc/configs/MyConfigName
-ln -s $HOME/probe-screen-ng/macros macros-psng
 ln -s $HOME/probe-screen-ng/psng psng
 ln -s $HOME/probe-screen-ng/python python
+```
 
-# to change branch
-git checkout files_cleanup
+To change branch: `git checkout files_cleanup`

--- a/docs/use-macro-hooks.md
+++ b/docs/use-macro-hooks.md
@@ -1,0 +1,28 @@
+# Use Macro Hooks
+
+To use macro hooks, you can do the following:
+
+```shell
+cd $HOME/linuxccnc/configs/MyConfigName
+cp psng/macros/psng_hook.ngc macros/psng_hook.ngc
+```
+
+Now, edit the `macros/psng_hook.ngc` file with the code you wish to run
+at the start of each PSNG macro call. For example:
+
+```gcode
+o<psng_hook> sub
+#<hooked_macro> = #1
+
+O100 if [#<hooked_macro> EQ psng_manual_change]
+; Do something specific to o<psng_manual_change> here
+O100 return
+
+O100 elseif  if [#<hooked_macro> EQ psng_gotots]
+; Do something specific to o<psng_gotots> here
+O100 return
+O100 endif
+
+o<psng_hook> endsub
+M2
+```

--- a/psng/install_add_to_your.ini
+++ b/psng/install_add_to_your.ini
@@ -29,7 +29,7 @@ Z = 60
 RETAIN_G43 = 0
 INI_VARS = 1
 HAL_PIN_VARS = 1
-SUBROUTINE_PATH = macros
+SUBROUTINE_PATH = macros:psng/macros
 REMAP=M6   modalgroup=6  prolog=change_prolog   ngc=psng_manual_change  epilog=change_epilog
 # ---- PSNG end ---- #
 

--- a/psng/macros/psng_block_down.ngc
+++ b/psng/macros/psng_block_down.ngc
@@ -1,5 +1,5 @@
 o<psng_block_down> sub
-o<psng_hook> call psng_block_down
+o<psng_hook> call [5]
 
 (cancel all Z offsets)
 G49

--- a/psng/macros/psng_block_down.ngc
+++ b/psng/macros/psng_block_down.ngc
@@ -1,4 +1,6 @@
 o<psng_block_down> sub
+o<psng_hook> call psng_block_down
+
 (cancel all Z offsets)
 G49
 G92.1

--- a/psng/macros/psng_down.ngc
+++ b/psng/macros/psng_down.ngc
@@ -1,5 +1,5 @@
 o<psng_down> sub
-o<psng_hook> call psng_down
+o<psng_hook> call [3]
 
 #<z>=#<_z> (save current Z position)
 G91

--- a/psng/macros/psng_down.ngc
+++ b/psng/macros/psng_down.ngc
@@ -1,5 +1,6 @@
 o<psng_down> sub
-	 
+o<psng_hook> call psng_down
+
 #<z>=#<_z> (save current Z position)
 G91
 F #<_hal[probe.ps_searchvel]>

--- a/psng/macros/psng_gotots.ngc
+++ b/psng/macros/psng_gotots.ngc
@@ -1,13 +1,11 @@
-o<psng_probe_down> sub
+o<psng_gotots> sub
+o<psng_hook> call psng_gotots
+
 F#<_ini[TOOLSENSOR]RAPID_SPEED>
 G90
-G53 G1 Z[#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+G53 G1 Z[#<_ini[AXIS_Z]MAX_LIMIT>]
 G53 G1 X[#<_ini[TOOLSENSOR]X>] Y[#<_ini[TOOLSENSOR]Y>]
 G53 G1 Z[#<_ini[TOOLSENSOR]Z>]
-(cancel all Z offsets)
-G92.1
-G49
-G10 L20 P0  Z[#<_hal[axis.z.pos-cmd]>]
 
 G91
 F #<_hal[probe.ps_searchvel]>
@@ -16,7 +14,8 @@ G1 Z[#<_hal[probe.ps_probe_latch]>] F#<_ini[TOOLSENSOR]RAPID_SPEED>
 F #<_hal[probe.ps_probevel]>
 G4 P0.5
 G38.2 Z[-#<_hal[probe.ps_probe_latch]>*2]
+G1 Z4 F#<_ini[TOOLSENSOR]RAPID_SPEED>
 G90
-G53 G1 Z[#<_ini[TOOLSENSOR]Z>] F#<_ini[TOOLSENSOR]RAPID_SPEED>	
-o<psng_probe_down> endsub
+o<psng_gotots> endsub
 M2
+

--- a/psng/macros/psng_gotots.ngc
+++ b/psng/macros/psng_gotots.ngc
@@ -1,5 +1,5 @@
 o<psng_gotots> sub
-o<psng_hook> call psng_gotots
+o<psng_hook> call [2]
 
 F#<_ini[TOOLSENSOR]RAPID_SPEED>
 G90

--- a/psng/macros/psng_hook.ngc
+++ b/psng/macros/psng_hook.ngc
@@ -1,0 +1,16 @@
+; End users can copy this file to their macros folder and edit as necessary.
+
+; This is useful to allow machine specific logic, such as checking HAL input
+; pins to ensure a probe or toolsetter are connected.
+
+; You should NOT edit this file directly, instead, you should copy this file
+; from the psng/macros folder, to the macros folder and edit the copy.
+
+o<psng_hook> sub
+; The #1 variable will be set to the name of the macro being hooked. For
+; example, when o<psng_manual_change> is called, #1 will be set to the
+; value "psng_manual_change".
+#<hooked_macro> = #1
+
+o<psng_hook> endsub
+M2

--- a/psng/macros/psng_hook.ngc
+++ b/psng/macros/psng_hook.ngc
@@ -6,10 +6,23 @@
 ; You should NOT edit this file directly, instead, you should copy this file
 ; from the psng/macros folder, to the macros folder and edit the copy.
 
+; Hooked Macro ID -> Name Table
+;
+; 1 = psng_manual_change
+; 2 = psng_gotots
+; 3 = psng_down
+; 4 = psng_probe_down
+; 5 = psng_block_down
+; 6 = psng_xminus
+; 7 = psng_xplus
+; 8 = psng_yminus
+; 9 = psng_yplus
+
+
 o<psng_hook> sub
 ; The #1 variable will be set to the name of the macro being hooked. For
-; example, when o<psng_manual_change> is called, #1 will be set to the
-; value "psng_manual_change".
+; example, when o<psng_xminus> is called, #1 will be set to the
+; value "6".
 #<hooked_macro> = #1
 
 o<psng_hook> endsub

--- a/psng/macros/psng_manual_change.ngc
+++ b/psng/macros/psng_manual_change.ngc
@@ -1,7 +1,7 @@
 ; manual toolchange with automatic tool length probe 
 
 o<psng_manual_change> sub
-o<psng_hook> call psng_manual_change
+o<psng_hook> call [1]
 
 ;(debug, in change tool_in_spindle=#<tool_in_spindle> current_pocket=#<current_pocket>)
 ;(debug, selected_tool=#<selected_tool> selected_pocket=#<selected_pocket>)

--- a/psng/macros/psng_manual_change.ngc
+++ b/psng/macros/psng_manual_change.ngc
@@ -1,6 +1,8 @@
 ; manual toolchange with automatic tool length probe 
 
 o<psng_manual_change> sub
+o<psng_hook> call psng_manual_change
+
 ;(debug, in change tool_in_spindle=#<tool_in_spindle> current_pocket=#<current_pocket>)
 ;(debug, selected_tool=#<selected_tool> selected_pocket=#<selected_pocket>)
 

--- a/psng/macros/psng_probe_down.ngc
+++ b/psng/macros/psng_probe_down.ngc
@@ -1,5 +1,5 @@
 o<psng_probe_down> sub
-o<psng_hook> call psng_probe_down
+o<psng_hook> call [4]
  
 F#<_ini[TOOLSENSOR]RAPID_SPEED>
 G90

--- a/psng/macros/psng_probe_down.ngc
+++ b/psng/macros/psng_probe_down.ngc
@@ -1,9 +1,15 @@
-o<psng_gotots> sub
+o<psng_probe_down> sub
+o<psng_hook> call psng_probe_down
+ 
 F#<_ini[TOOLSENSOR]RAPID_SPEED>
 G90
-G53 G1 Z[#<_ini[AXIS_Z]MAX_LIMIT>]
+G53 G1 Z[#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 G53 G1 X[#<_ini[TOOLSENSOR]X>] Y[#<_ini[TOOLSENSOR]Y>]
 G53 G1 Z[#<_ini[TOOLSENSOR]Z>]
+(cancel all Z offsets)
+G92.1
+G49
+G10 L20 P0  Z[#<_hal[axis.z.pos-cmd]>]
 
 G91
 F #<_hal[probe.ps_searchvel]>
@@ -12,8 +18,7 @@ G1 Z[#<_hal[probe.ps_probe_latch]>] F#<_ini[TOOLSENSOR]RAPID_SPEED>
 F #<_hal[probe.ps_probevel]>
 G4 P0.5
 G38.2 Z[-#<_hal[probe.ps_probe_latch]>*2]
-G1 Z4 F#<_ini[TOOLSENSOR]RAPID_SPEED>
 G90
-o<psng_gotots> endsub
+G53 G1 Z[#<_ini[TOOLSENSOR]Z>] F#<_ini[TOOLSENSOR]RAPID_SPEED>	
+o<psng_probe_down> endsub
 M2
-

--- a/psng/macros/psng_xminus.ngc
+++ b/psng/macros/psng_xminus.ngc
@@ -1,5 +1,5 @@
 o<psng_xminus> sub
-o<psng_hook> call psng_xminus
+o<psng_hook> call [6]
 
 #<x>=#<_x> (save start X position) 
 G91

--- a/psng/macros/psng_xminus.ngc
+++ b/psng/macros/psng_xminus.ngc
@@ -1,5 +1,6 @@
 o<psng_xminus> sub
-	 	
+o<psng_hook> call psng_xminus
+
 #<x>=#<_x> (save start X position) 
 G91
 F #<_hal[probe.ps_searchvel]>

--- a/psng/macros/psng_xplus.ngc
+++ b/psng/macros/psng_xplus.ngc
@@ -1,5 +1,5 @@
 o<psng_xplus> sub
-o<psng_hook> call psng_xplus
+o<psng_hook> call [7]
 
 #<x>=#<_x> (save start X position) 
 G91

--- a/psng/macros/psng_xplus.ngc
+++ b/psng/macros/psng_xplus.ngc
@@ -1,5 +1,6 @@
 o<psng_xplus> sub
-	
+o<psng_hook> call psng_xplus
+
 #<x>=#<_x> (save start X position) 
 G91
 F #<_hal[probe.ps_searchvel]>

--- a/psng/macros/psng_yminus.ngc
+++ b/psng/macros/psng_yminus.ngc
@@ -1,4 +1,5 @@
 o<psng_yminus> sub
+o<psng_hook> call psng_yminus
 
 #<y>=#<_y> (save start Y position) 
 G91

--- a/psng/macros/psng_yminus.ngc
+++ b/psng/macros/psng_yminus.ngc
@@ -1,5 +1,5 @@
 o<psng_yminus> sub
-o<psng_hook> call psng_yminus
+o<psng_hook> call [8]
 
 #<y>=#<_y> (save start Y position) 
 G91

--- a/psng/macros/psng_yplus.ngc
+++ b/psng/macros/psng_yplus.ngc
@@ -1,5 +1,6 @@
 o<psng_yplus> sub
- 	
+o<psng_hook> call psng_yplus
+
 #<y>=#<_y> (save start Y position) 
 G91
 F #<_hal[probe.ps_searchvel]>

--- a/psng/macros/psng_yplus.ngc
+++ b/psng/macros/psng_yplus.ngc
@@ -1,5 +1,5 @@
 o<psng_yplus> sub
-o<psng_hook> call psng_yplus
+o<psng_hook> call [9]
 
 #<y>=#<_y> (save start Y position) 
 G91

--- a/psng/psng.hal
+++ b/psng/psng.hal
@@ -1,6 +1,12 @@
+# Ensure all toolchange pins are free to use
+unlinkp iocontrol.0.tool-prep-number
+unlinkp iocontrol.0.tool-change
+unlinkp iocontrol.0.tool-changed
+unlinkp iocontrol.0.tool-prepare
+unlinkp iocontrol.0.tool-prepared
+
 net tool-change            probe.toolchange-change    <=   iocontrol.0.tool-change 
 net tool-changed           probe.toolchange-changed   =>   iocontrol.0.tool-changed
 net tool-prep-number       probe.toolchange-number    <=   iocontrol.0.tool-prep-number
-
-net tool-prep-loop         iocontrol.0.tool-prepare      <=   iocontrol.0.tool-prepared
+net tool-prep-loop         iocontrol.0.tool-prepare   <=   iocontrol.0.tool-prepared
 


### PR DESCRIPTION
**Totally Untested**


Add a method to hook each of the PSNG macros with custom code. Every existing macro now calls into a `psng_hook` macro, allowing the user to add custom code to be ran at the beginning of each macro - for example, validating that a probe or tool setter is connected.

The PSNG macros were moved into the `psng` folder, and both user macros (`MyConfigDir/macros`) and PSNG macros (`MyConfigDir/psng/macros`) will be available.

If a macro (e.g. `psng_hook.ngc` is found in the user macros dir, it will be used. If it's not found there, then the default one from the PSNG macros folder will be used.

Some basic docs have been added to `docs/use-macro-hooks.md`

Things to note:

1) The PSNG macros folder has moved.
2) The INI setting for SUBROUTINE_PATH has changed.