### PR TITLE
Check psng_hook return value for error conditions

### DIFF
--- a/psng/macros/psng_gotots.ngc
+++ b/psng/macros/psng_gotots.ngc
@@ -1,5 +1,10 @@
 o<psng_gotots> sub
+
+; Call the PSNG Hook and check return value
 o<psng_hook> call [2]
+o10 if [#<_value> LT 0]
+(ABORT, PSNG hook indicated a failure: #<_value>)
+o10 endif
 
 ; first go up then move to tool sensor position
 G90

--- a/psng/macros/psng_hook.ngc
+++ b/psng/macros/psng_hook.ngc
@@ -25,5 +25,5 @@ o<psng_hook> sub
 ; value "6".
 #<hooked_macro> = #1
 
-o<psng_hook> endsub
+o<psng_hook> endsub [0]
 M2

--- a/psng/macros/psng_manual_change.ngc
+++ b/psng/macros/psng_manual_change.ngc
@@ -1,7 +1,11 @@
 ; manual toolchange with automatic tool length probe
-
 o<psng_manual_change> sub
+
+; Call the PSNG Hook and check return value
 o<psng_hook> call [1]
+o10 if [#<_value> LT 0]
+(ABORT, PSNG hook indicated a failure: #<_value>)
+o10 endif
 
 ;(debug, in change tool_in_spindle=#<tool_in_spindle> current_pocket=#<current_pocket>)
 ;(debug, selected_tool=#<selected_tool> selected_pocket=#<selected_pocket>)

--- a/psng/macros/psng_probe_table.ngc
+++ b/psng/macros/psng_probe_table.ngc
@@ -1,5 +1,10 @@
 o<psng_probe_table> sub
+
+; Call the PSNG Hook and check return value
 o<psng_hook> call [3]
+o10 if [#<_value> LT 0]
+(ABORT, PSNG hook indicated a failure: #<_value>)
+o10 endif
 
 #<z>=#<_z> (save current Z position)
 G91

--- a/psng/macros/psng_probe_tool_setter.ngc
+++ b/psng/macros/psng_probe_tool_setter.ngc
@@ -1,5 +1,10 @@
 o<psng_probe_tool_setter> sub
+
+; Call the PSNG Hook and check return value
 o<psng_hook> call [4]
+o10 if [#<_value> LT 0]
+(ABORT, PSNG hook indicated a failure: #<_value>)
+o10 endif
 
 ; first go up then move to tool sensor position
 G90

--- a/psng/macros/psng_probe_workpiece.ngc
+++ b/psng/macros/psng_probe_workpiece.ngc
@@ -1,5 +1,10 @@
 o<psng_probe_workpiece> sub
+
+; Call the PSNG Hook and check return value
 o<psng_hook> call [5]
+o10 if [#<_value> LT 0]
+(ABORT, PSNG hook indicated a failure: #<_value>)
+o10 endif
 
 (cancel all Z offsets)
 G49

--- a/psng/macros/psng_xminus.ngc
+++ b/psng/macros/psng_xminus.ngc
@@ -1,5 +1,10 @@
 o<psng_xminus> sub
+
+; Call the PSNG Hook and check return value
 o<psng_hook> call [6]
+o10 if [#<_value> LT 0]
+(ABORT, PSNG hook indicated a failure: #<_value>)
+o10 endif
 
 #<x>=#<_x> (save start X position)
 G91

--- a/psng/macros/psng_xplus.ngc
+++ b/psng/macros/psng_xplus.ngc
@@ -1,5 +1,10 @@
 o<psng_xplus> sub
+
+; Call the PSNG Hook and check return value
 o<psng_hook> call [7]
+o10 if [#<_value> LT 0]
+(ABORT, PSNG hook indicated a failure: #<_value>)
+o10 endif
 
 #<x>=#<_x> (save start X position)
 G91

--- a/psng/macros/psng_yminus.ngc
+++ b/psng/macros/psng_yminus.ngc
@@ -1,5 +1,10 @@
 o<psng_yminus> sub
+
+; Call the PSNG Hook and check return value
 o<psng_hook> call [8]
+o10 if [#<_value> LT 0]
+(ABORT, PSNG hook indicated a failure: #<_value>)
+o10 endif
 
 #<y>=#<_y> (save start Y position)
 G91

--- a/psng/macros/psng_yplus.ngc
+++ b/psng/macros/psng_yplus.ngc
@@ -1,5 +1,10 @@
 o<psng_yplus> sub
+
+; Call the PSNG Hook and check return value
 o<psng_hook> call [9]
+o10 if [#<_value> LT 0]
+(ABORT, PSNG hook indicated a failure: #<_value>)
+o10 endif
 
 #<y>=#<_y> (save start Y position)
 G91


### PR DESCRIPTION
Any return value less than 0 will be treated as a failure, and will abort
the remainder of the macro execution.