### PR TITLE
Refactor Spin Button Key Press and Value Changed handlers

### DIFF
--- a/psng/python/base.py
+++ b/psng/python/base.py
@@ -25,6 +25,7 @@ from subprocess import PIPE, Popen
 
 import gtk
 import linuxcnc
+import pango
 
 from .configparser import ProbeScreenConfigParser
 from .util import restore_task_mode
@@ -395,3 +396,23 @@ class ProbeScreenBase(object):
             res = ym - yp
         self.display_result_ly(res)
         return res
+
+    # --------------------------
+    #
+    #  Generic UI Methods
+    #
+    # --------------------------
+    def on_common_spbtn_key_press_event(self, pin_name, gtkspinbutton, data=None):
+        keyname = gtk.gdk.keyval_name(data.keyval)
+        if keyname == "Return":
+            # Drop the Italics
+            gtkspinbutton.modify_font(pango.FontDescription("normal"))
+        elif keyname == "Escape":
+            # Restore the original value
+            gtkspinbutton.set_value(self.halcomp[pin_name])
+
+            # Drop the Italics
+            gtkspinbutton.modify_font(pango.FontDescription("normal"))
+        else:
+            # Set to Italics
+            gtkspinbutton.modify_font(pango.FontDescription("italic"))

--- a/psng/python/base.py
+++ b/psng/python/base.py
@@ -416,3 +416,13 @@ class ProbeScreenBase(object):
         else:
             # Set to Italics
             gtkspinbutton.modify_font(pango.FontDescription("italic"))
+
+    def on_common_spbtn_value_changed(self, pin_name, gtkspinbutton, data=None, _type=float):
+        # Drop the Italics
+        gtkspinbutton.modify_font(pango.FontDescription("normal"))
+
+        # Update the pin
+        self.halcomp[pin_name] = gtkspinbutton.get_value()
+
+        # Update the preferences
+        self.prefs.putpref(pin_name, gtkspinbutton.get_value(), _type)

--- a/psng/python/rotation.py
+++ b/psng/python/rotation.py
@@ -79,11 +79,7 @@ class ProbeScreenRotation(ProbeScreenBase):
         time.sleep(1)
 
     def on_spbtn_offs_angle_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_offs_angle", gtkspinbutton, data)
 
     def on_spbtn_offs_angle_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))

--- a/psng/python/rotation.py
+++ b/psng/python/rotation.py
@@ -19,9 +19,7 @@
 import math
 import time
 
-import gtk  # base for pygtk widgets and constants
-import hal  # base hal class to react to hal signals
-import pango
+import hal
 
 from .base import ProbeScreenBase
 
@@ -82,9 +80,7 @@ class ProbeScreenRotation(ProbeScreenBase):
         self.on_common_spbtn_key_press_event("ps_offs_angle", gtkspinbutton, data)
 
     def on_spbtn_offs_angle_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_offs_angle"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_offs_angle", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_value_changed("ps_offs_angle", gtkspinbutton, data)
 
     # Y+Y+
     def on_angle_yp_released(self, gtkbutton, data=None):

--- a/psng/python/settings.py
+++ b/psng/python/settings.py
@@ -16,9 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
-import gtk  # base for pygtk widgets and constants
-import hal  # base hal class to react to hal signals
-import pango
+import hal
 
 from .base import ProbeScreenBase
 
@@ -97,62 +95,46 @@ class ProbeScreenSettings(ProbeScreenBase):
         self.on_common_spbtn_key_press_event("ps_searchvel", gtkspinbutton, data)
 
     def on_spbtn1_search_vel_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal "))
-        self.halcomp["ps_searchvel"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_searchvel", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_value_changed("ps_searchvel", gtkspinbutton, data)
 
     def on_spbtn1_probe_vel_key_press_event(self, gtkspinbutton, data=None):
         self.on_common_spbtn_key_press_event("ps_probevel", gtkspinbutton, data)
 
     def on_spbtn1_probe_vel_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_probevel"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_probevel", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_value_changed("ps_probevel", gtkspinbutton, data)
 
     def on_spbtn1_probe_max_key_press_event(self, gtkspinbutton, data=None):
         self.on_common_spbtn_key_press_event("ps_probe_max", gtkspinbutton, data)
 
     def on_spbtn1_probe_max_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_probe_max"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_probe_max", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_value_changed("ps_probe_max", gtkspinbutton, data)
 
     def on_spbtn1_probe_latch_key_press_event(self, gtkspinbutton, data=None):
         self.on_common_spbtn_key_press_event("ps_probe_latch", gtkspinbutton, data)
 
     def on_spbtn1_probe_latch_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_probe_latch"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_probe_latch", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_value_changed("ps_probe_latch", gtkspinbutton, data)
 
     def on_spbtn1_probe_diam_key_press_event(self, gtkspinbutton, data=None):
         self.on_common_spbtn_key_press_event("ps_probe_diam", gtkspinbutton, data)
 
     def on_spbtn1_probe_diam_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_probe_diam"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_probe_diam", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_value_changed("ps_probe_diam", gtkspinbutton, data)
 
     def on_spbtn1_xy_clearance_key_press_event(self, gtkspinbutton, data=None):
         self.on_common_spbtn_key_press_event("ps_xy_clearance", gtkspinbutton, data)
 
     def on_spbtn1_xy_clearance_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_xy_clearance"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_xy_clearance", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_value_changed("ps_xy_clearance", gtkspinbutton, data)
 
     def on_spbtn1_edge_lenght_key_press_event(self, gtkspinbutton, data=None):
         self.on_common_spbtn_key_press_event("ps_edge_lenght", gtkspinbutton, data)
 
     def on_spbtn1_edge_lenght_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_edge_lenght"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_edge_lenght", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_value_changed("ps_edge_lenght", gtkspinbutton, data)
 
     def on_spbtn1_z_clearance_key_press_event(self, gtkspinbutton, data=None):
         self.on_common_spbtn_key_press_event("ps_z_clearance", gtkspinbutton, data)
 
     def on_spbtn1_z_clearance_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_z_clearance"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_z_clearance", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_value_changed("ps_z_clearance", gtkspinbutton, data)

--- a/psng/python/settings.py
+++ b/psng/python/settings.py
@@ -94,12 +94,7 @@ class ProbeScreenSettings(ProbeScreenBase):
     # Settings Buttons
     # ----------------
     def on_spbtn1_search_vel_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        #        print "Key %s (%d) was pressed" % (keyname, data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_searchvel", gtkspinbutton, data)
 
     def on_spbtn1_search_vel_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal "))
@@ -107,11 +102,7 @@ class ProbeScreenSettings(ProbeScreenBase):
         self.prefs.putpref("ps_searchvel", gtkspinbutton.get_value(), float)
 
     def on_spbtn1_probe_vel_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_probevel", gtkspinbutton, data)
 
     def on_spbtn1_probe_vel_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))
@@ -119,11 +110,7 @@ class ProbeScreenSettings(ProbeScreenBase):
         self.prefs.putpref("ps_probevel", gtkspinbutton.get_value(), float)
 
     def on_spbtn1_probe_max_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_probe_max", gtkspinbutton, data)
 
     def on_spbtn1_probe_max_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))
@@ -131,11 +118,7 @@ class ProbeScreenSettings(ProbeScreenBase):
         self.prefs.putpref("ps_probe_max", gtkspinbutton.get_value(), float)
 
     def on_spbtn1_probe_latch_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_probe_latch", gtkspinbutton, data)
 
     def on_spbtn1_probe_latch_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))
@@ -143,11 +126,7 @@ class ProbeScreenSettings(ProbeScreenBase):
         self.prefs.putpref("ps_probe_latch", gtkspinbutton.get_value(), float)
 
     def on_spbtn1_probe_diam_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_probe_diam", gtkspinbutton, data)
 
     def on_spbtn1_probe_diam_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))
@@ -155,11 +134,7 @@ class ProbeScreenSettings(ProbeScreenBase):
         self.prefs.putpref("ps_probe_diam", gtkspinbutton.get_value(), float)
 
     def on_spbtn1_xy_clearance_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_xy_clearance", gtkspinbutton, data)
 
     def on_spbtn1_xy_clearance_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))
@@ -167,11 +142,7 @@ class ProbeScreenSettings(ProbeScreenBase):
         self.prefs.putpref("ps_xy_clearance", gtkspinbutton.get_value(), float)
 
     def on_spbtn1_edge_lenght_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_edge_lenght", gtkspinbutton, data)
 
     def on_spbtn1_edge_lenght_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))
@@ -179,11 +150,7 @@ class ProbeScreenSettings(ProbeScreenBase):
         self.prefs.putpref("ps_edge_lenght", gtkspinbutton.get_value(), float)
 
     def on_spbtn1_z_clearance_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_z_clearance", gtkspinbutton, data)
 
     def on_spbtn1_z_clearance_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))

--- a/psng/python/tool_measurement.py
+++ b/psng/python/tool_measurement.py
@@ -124,12 +124,7 @@ class ProbeScreenToolMeasurement(ProbeScreenBase):
 
     # Spinbox for setter height with autosave value inside machine pref file
     def on_spbtn_setter_height_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        #        print "Key %s (%d) was pressed" % (keyname, data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("setterheight", gtkspinbutton, data)
 
     def on_spbtn_setter_height_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal "))
@@ -145,12 +140,7 @@ class ProbeScreenToolMeasurement(ProbeScreenBase):
 
     # Spinbox for block height with autosave value inside machine pref file
     def on_spbtn_block_height_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        #        print "Key %s (%d) was pressed" % (keyname, data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("blockheight", gtkspinbutton, data)
 
     def on_spbtn_block_height_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal "))

--- a/psng/python/tool_measurement.py
+++ b/psng/python/tool_measurement.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
-import gtk
+import sys
+import os
 import hal
 import hal_glib
-import pango
 
 from .base import ProbeScreenBase
 
@@ -127,9 +127,8 @@ class ProbeScreenToolMeasurement(ProbeScreenBase):
         self.on_common_spbtn_key_press_event("setterheight", gtkspinbutton, data)
 
     def on_spbtn_setter_height_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal "))
-        self.halcomp["setterheight"] = gtkspinbutton.get_value()
-        self.prefs.putpref("setterheight", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_value_changed("setterheight", gtkspinbutton, data)
+
         c = "TS Height = " + "%.4f" % gtkspinbutton.get_value()
         i = self.buffer.get_end_iter()
         if i.get_line() > 1000:
@@ -143,22 +142,10 @@ class ProbeScreenToolMeasurement(ProbeScreenBase):
         self.on_common_spbtn_key_press_event("blockheight", gtkspinbutton, data)
 
     def on_spbtn_block_height_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal "))
-        blockheight = gtkspinbutton.get_value()
-        if blockheight != False:
-            self.halcomp["blockheight"] = blockheight
-            self.halcomp["setterheight"] = self.spbtn_setter_height.get_value()
-        else:
-            self.prefs.putpref("blockheight", 0.0, float)
-            print(_("Conversion error in btn_block_height"))
-            self._add_alarm_entry(_("Offset conversion error because off wrong entry"))
-            self.warning_dialog(
-                self,
-                _("Conversion error in btn_block_height!"),
-                _("Please enter only numerical values\nValues have not been applied"),
-            )
+        self.on_common_spbtn_value_changed("blockheight", gtkspinbutton, data)
+
         # set koordinate system to new origin
-        self.gcode("G10 L2 P0 Z%s" % blockheight)
+        self.gcode("G10 L2 P0 Z%s" % gtkspinbutton.get_value())
         self.vcp_reload()
         c = "Workpiece Height = " + "%.4f" % gtkspinbutton.get_value()
         i = self.buffer.get_end_iter()

--- a/psng/python/zero.py
+++ b/psng/python/zero.py
@@ -16,9 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
-import gtk  # base for pygtk widgets and constants
-import hal  # base hal class to react to hal signals
-import pango
+import hal
 
 from .base import ProbeScreenBase
 
@@ -67,9 +65,7 @@ class ProbeScreenZero(ProbeScreenBase):
         self.on_common_spbtn_key_press_event("ps_offs_x", gtkspinbutton, data)
 
     def on_spbtn_offs_x_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_offs_x"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_offs_x", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_key_press_event("ps_offs_x", gtkspinbutton, data)
 
     def on_btn_set_x_released(self, gtkbutton, data=None):
         self.prefs.putpref("ps_offs_x", self.spbtn_offs_x.get_value(), float)
@@ -80,9 +76,7 @@ class ProbeScreenZero(ProbeScreenBase):
         self.on_common_spbtn_key_press_event("ps_offs_y", gtkspinbutton, data)
 
     def on_spbtn_offs_y_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_offs_y"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_offs_y", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_key_press_event("ps_offs_y", gtkspinbutton, data)
 
     def on_btn_set_y_released(self, gtkbutton, data=None):
         self.prefs.putpref("ps_offs_y", self.spbtn_offs_y.get_value(), float)
@@ -93,9 +87,7 @@ class ProbeScreenZero(ProbeScreenBase):
         self.on_common_spbtn_key_press_event("ps_offs_z", gtkspinbutton, data)
 
     def on_spbtn_offs_z_value_changed(self, gtkspinbutton, data=None):
-        gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        self.halcomp["ps_offs_z"] = gtkspinbutton.get_value()
-        self.prefs.putpref("ps_offs_z", gtkspinbutton.get_value(), float)
+        self.on_common_spbtn_key_press_event("ps_offs_z", gtkspinbutton, data)
 
     def on_btn_set_z_released(self, gtkbutton, data=None):
         self.prefs.putpref("ps_offs_z", self.spbtn_offs_z.get_value(), float)

--- a/psng/python/zero.py
+++ b/psng/python/zero.py
@@ -64,11 +64,7 @@ class ProbeScreenZero(ProbeScreenBase):
         self.prefs.putpref("chk_set_zero", gtkcheckbutton.get_active(), bool)
 
     def on_spbtn_offs_x_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_offs_x", gtkspinbutton, data)
 
     def on_spbtn_offs_x_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))
@@ -81,11 +77,7 @@ class ProbeScreenZero(ProbeScreenBase):
         self.vcp_reload()
 
     def on_spbtn_offs_y_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_offs_y", gtkspinbutton, data)
 
     def on_spbtn_offs_y_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))
@@ -98,11 +90,7 @@ class ProbeScreenZero(ProbeScreenBase):
         self.vcp_reload()
 
     def on_spbtn_offs_z_key_press_event(self, gtkspinbutton, data=None):
-        keyname = gtk.gdk.keyval_name(data.keyval)
-        if keyname == "Return":
-            gtkspinbutton.modify_font(pango.FontDescription("normal"))
-        else:
-            gtkspinbutton.modify_font(pango.FontDescription("italic"))
+        self.on_common_spbtn_key_press_event("ps_offs_z", gtkspinbutton, data)
 
     def on_spbtn_offs_z_value_changed(self, gtkspinbutton, data=None):
         gtkspinbutton.modify_font(pango.FontDescription("normal"))


### PR DESCRIPTION
Additionally:

* When "Escape" is pressed, undo any changes that have been typed in but not yet saved.
* Remove some dead code in the block_height_value_changed method. This code simply couldn't have worked, as it's calling a `_add_alarm_entry` method which does not exist.